### PR TITLE
Adding allow-methods header to evercookie controller

### DIFF
--- a/lib/evercookie/controller.rb
+++ b/lib/evercookie/controller.rb
@@ -110,7 +110,8 @@ module Evercookie
 
     private
     def allow_unrestricted_access
-      headers['Access-Control-Allow-Origin'] = '*'
+      response.headers['Access-Control-Allow-Origin'] = '*'
+      response.headers['Access-Control-Allow-Methods'] = '*'
     end
 
     def get_blob_png


### PR DESCRIPTION
servers were also making requests with OPTIONS method, which was not being allowed.
