### PR TITLE
ARCT-154 Mimic the behavior of daddyz gem and set path arg to root.

### DIFF
--- a/app/assets/javascripts/evercookie/evercookie.js.erb
+++ b/app/assets/javascripts/evercookie/evercookie.js.erb
@@ -299,7 +299,7 @@ var <%= Evercookie.js_class %> = (function (window) {
             params.swliveconnect = "true";
             attributes.id        = "myswf";
             attributes.name      = "myswf";
-            swfobject.embedSWF("<%= asset_path('ec.swf') %>", "swfcontainer", "1", "1", "9.0.0", false, flashvars, params, attributes);
+            swfobject.embedSWF(this.full_url("<%= asset_path('ec.swf', host: '') %>", {}), "swfcontainer", "1", "1", "9.0.0", false, flashvars, params, attributes);
         };
 
         this.<%= Evercookie.js_class %>_png = function (name, value) {

--- a/app/assets/javascripts/evercookie/evercookie.js.erb
+++ b/app/assets/javascripts/evercookie/evercookie.js.erb
@@ -56,7 +56,8 @@ var <%= Evercookie.js_class %> = (function (window) {
         // private property
         var self = this,
                 _baseKeyStr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
-                no_color = -1;
+                no_color = -1,
+                ec_domain = '.' + window.location.host.replace(/:\d+/, '');
         this._ec = {};
 
         this.get = function (name, cb, dont_reset) {
@@ -156,7 +157,7 @@ var <%= Evercookie.js_class %> = (function (window) {
                     }
 
                     self.ajax({
-                        url: "<%= Evercookie.get_save_path %>?name=" + name,
+                        url: this.full_url("<%= Evercookie.get_save_path %>", {name: name}),
                         success: function (data) { }
                     });
                 }
@@ -234,21 +235,21 @@ var <%= Evercookie.js_class %> = (function (window) {
         this.<%= Evercookie.js_class %>_cache = function (name, value) {
             if (value !== undefined) {
                 // make sure we have <%= Evercookie.js_class %> session defined first
-                document.cookie = "<%= Evercookie.cookie_cache %>=" + value + "; path=<%= Evercookie.get_cookie_path %>";
+                document.cookie = "<%= Evercookie.cookie_cache %>=" + value + "; path=/; domain=" + ec_domain;
                 // <%= Evercookie.get_cache_path %> handles caching
-                newImage("<%= Evercookie.get_cache_path %>?name=" + name);
+                newImage(this.full_url("<%= Evercookie.get_cache_path %>", {name: name}));
             } else {
                 // interestingly enough, we want to erase our evercookie
                 // http cookie so will force a cached response
                 var origvalue = this.getFromStr("<%= Evercookie.cookie_cache %>", document.cookie);
                 self._ec.cacheData = undefined;
-                document.cookie = "<%= Evercookie.cookie_cache %>=; expires=Mon, 20 Sep 2010 00:00:00 UTC; path=<%= Evercookie.get_cookie_path %>";
 
+                document.cookie = "<%= Evercookie.cookie_cache %>=; expires=Mon, 20 Sep 2010 00:00:00 UTC; path=/; domain=" + ec_domain;
                 self.ajax({
-                    url: "<%= Evercookie.get_cache_path %>?name=" + name,
+                    url: this.full_url("<%= Evercookie.get_cache_path %>", {name: name}),
                     success: function (data) {
                         // put our cookie back
-                        document.cookie = "<%= Evercookie.cookie_cache %>=" + origvalue + "; expires=Tue, 31 Dec 2030 00:00:00 UTC; path=<%= Evercookie.get_cookie_path %>";
+                        document.cookie = "<%= Evercookie.cookie_cache %>=" + origvalue + "; expires=Tue, 31 Dec 2030 00:00:00 UTC; path=/; domain=" + ec_domain;
 
                         self._ec.cacheData = data;
                     }
@@ -259,21 +260,21 @@ var <%= Evercookie.js_class %> = (function (window) {
         this.<%= Evercookie.js_class %>_etag = function (name, value) {
             if (value !== undefined) {
                 // make sure we have <%= Evercookie.js_class %> session defined first
-                document.cookie = "<%= Evercookie.cookie_etag %>=" + value + "; path=<%= Evercookie.get_cookie_path %>";
+                document.cookie = "<%= Evercookie.cookie_etag %>=" + value + "; path=/; domain=" + ec_domain;
                 // <%= Evercookie.get_etag_path %> handles etagging
-                newImage("<%= Evercookie.get_etag_path %>?name=" + name);
+                newImage(this.full_url("<%= Evercookie.get_etag_path %>", {name: name}));
             } else {
                 // interestingly enough, we want to erase our <%= Evercookie.js_class %>
                 // http cookie so will force a cached response
                 var origvalue = this.getFromStr("<%= Evercookie.cookie_etag %>", document.cookie);
                 self._ec.etagData = undefined;
-                document.cookie = "<%= Evercookie.cookie_etag %>=; expires=Mon, 20 Sep 2010 00:00:00 UTC; path=<%= Evercookie.get_cookie_path %>";
+                document.cookie = "<%= Evercookie.cookie_etag %>=; expires=Mon, 20 Sep 2010 00:00:00 UTC; path=/; domain=" + ec_domain;
 
                 self.ajax({
-                    url: "<%= Evercookie.get_etag_path %>?name=" + name,
+                    url: this.full_url("<%= Evercookie.get_etag_path %>", {name: name}),
                     success: function (data) {
                         // put our cookie back
-                        document.cookie = "<%= Evercookie.cookie_etag %>=" + origvalue + "; expires=Tue, 31 Dec 2030 00:00:00 UTC; path=<%= Evercookie.get_cookie_path %>";
+                        document.cookie = "<%= Evercookie.cookie_etag %>=" + origvalue + "; expires=Tue, 31 Dec 2030 00:00:00 UTC; path=/; domain=" + ec_domain;
 
                         self._ec.etagData = data;
                     }
@@ -314,9 +315,10 @@ var <%= Evercookie.js_class %> = (function (window) {
                 img = new Image();
                 img.style.visibility = "hidden";
                 img.style.position = "absolute";
+                img.crossOrigin = "Anonymous";
                 if (value !== undefined) {
                     // make sure we have <%= Evercookie.js_class %> session defined first
-                    document.cookie = "<%= Evercookie.cookie_png %>=" + value + "; path=<%= Evercookie.get_cookie_path %>";
+                    document.cookie = "<%= Evercookie.cookie_png %>=" + value + "; path=/; domain=" + ec_domain;;
                 } else {
                     self._ec.pngData = undefined;
                     ctx = canvas.getContext("2d");
@@ -324,11 +326,11 @@ var <%= Evercookie.js_class %> = (function (window) {
                     // interestingly enough, we want to erase our <%= Evercookie.js_class %>
                     // http cookie so will force a cached response
                     origvalue = this.getFromStr("<%= Evercookie.cookie_png %>", document.cookie);
-                    document.cookie = "<%= Evercookie.cookie_png %>=; expires=Mon, 20 Sep 2010 00:00:00 UTC; path=<%= Evercookie.get_cookie_path %>";
+                    document.cookie = "<%= Evercookie.cookie_png %>=; expires=Mon, 20 Sep 2010 00:00:00 UTC; path=/; domain=" + ec_domain;
 
                     img.onload = function () {
                         // put our cookie back
-                        document.cookie = "<%= Evercookie.cookie_png %>=" + origvalue + "; expires=Tue, 31 Dec 2030 00:00:00 UTC; path=<%= Evercookie.get_cookie_path %>";
+                        document.cookie = "<%= Evercookie.cookie_png %>=" + origvalue + "; expires=Tue, 31 Dec 2030 00:00:00 UTC; path=/; domain=" + ec_domain;
 
                         self._ec.pngData = "";
                         ctx.drawImage(img, 0, 0);
@@ -354,9 +356,13 @@ var <%= Evercookie.js_class %> = (function (window) {
                         }
                     };
                 }
-                img.src = "<%= Evercookie.get_png_path %>?name=" + name;
+                img.src = this.full_url("<%= Evercookie.get_png_path %>", {name: name});
             }
         };
+
+        this.full_url = function(path, params) {
+            return this.getHost() + path + '?' + $.param(params)
+        }
 
         this.<%= Evercookie.js_class %>_local_storage = function (name, value) {
             try {
@@ -583,8 +589,8 @@ var <%= Evercookie.js_class %> = (function (window) {
         this.<%= Evercookie.js_class %>_cookie = function (name, value) {
             if (value !== undefined) {
                 // expire the cookie first
-                document.cookie = name + "=; expires=Mon, 20 Sep 2010 00:00:00 UTC; path=<%= Evercookie.get_cookie_path %>";
-                document.cookie = name + "=" + value + "; expires=Tue, 31 Dec 2030 00:00:00 UTC; path=<%= Evercookie.get_cookie_path %>";
+                document.cookie = name + "=; expires=Mon, 20 Sep 2010 00:00:00 UTC; path=/; domain=" + ec_domain;
+                document.cookie = name + "=" + value + "; expires=Tue, 31 Dec 2030 00:00:00 UTC; path=/; domain=" + ec_domain;
             } else {
                 return this.getFromStr(name, document.cookie);
             }
@@ -610,7 +616,7 @@ var <%= Evercookie.js_class %> = (function (window) {
         };
 
         this.getHost = function () {
-            return '<%= Evercookie.host_url %>';
+            return "<%= Evercookie.host_url %>".replace('http:', window.location.protocol);
         };
 
         this.toHex = function (str) {

--- a/app/assets/javascripts/evercookie/evercookie.js.erb
+++ b/app/assets/javascripts/evercookie/evercookie.js.erb
@@ -361,7 +361,11 @@ var <%= Evercookie.js_class %> = (function (window) {
         };
 
         this.full_url = function(path, params) {
-            return this.getHost() + path + '?' + $.param(params)
+            var encoded_params = [];
+            for (param in params) {
+                encoded_params.push(encodeURIComponent(param) + "=" + encodeURIComponent(params[param]))
+            }
+            return this.getHost() + path + '?' + encoded_params.join("&");
         }
 
         this.<%= Evercookie.js_class %>_local_storage = function (name, value) {

--- a/lib/evercookie.rb
+++ b/lib/evercookie.rb
@@ -31,7 +31,7 @@ module Evercookie
 
   # name for host url
   mattr_accessor :host_url
-  @@host_url = 'http://www.weddingwire.com/'
+  @@host_url = 'http://www.weddingwire.com'
 
   # default method for setup evercookie
   def self.setup
@@ -45,43 +45,37 @@ module Evercookie
 
   # getter for session key variable for set action
   def self.hash_name_for_set
-    "#{@@host_url}#{@@hash_name}_set".to_sym
+    "#{@@hash_name}_set".to_sym
   end
 
   # getter for session key variable for get action
   def self.hash_name_for_get
-    "#{@@host_url}#{@@hash_name}_get".to_sym
+    "#{@@hash_name}_get".to_sym
   end
 
   # getter for session key variable all stored evercookies
   def self.hash_name_for_saved
-    "#{@@host_url}#{@@hash_name}_saved".to_sym
-  end
-
-  # getter for cookie path in javascript because rails controller actions
-  # get cookies only from it's controller path
-  def self.get_cookie_path
-    "#{@@host_url}#{get_namespace}/"
+    "#{@@hash_name}_saved".to_sym
   end
 
   # getter for path of save action
   def self.get_save_path
-    "#{@@host_url}#{get_namespace}/save"
+    "/#{get_namespace}/save"
   end
 
   # getter for path of cache action
   def self.get_cache_path
-    "#{@@host_url}#{get_namespace}/ec_cache"
+    "/#{get_namespace}/ec_cache"
   end
 
   # getter for path of etag action
   def self.get_etag_path
-    "#{@@host_url}#{get_namespace}/ec_etag"
+    "/#{get_namespace}/ec_etag"
   end
 
   # getter for path of png action
   def self.get_png_path
-    "#{@@host_url}#{get_namespace}/ec_png"
+    "/#{get_namespace}/ec_png"
   end
 end
 


### PR DESCRIPTION
Explictly settin the domain. Reference the host url when grabbing
assets, but use the protocol of the current page when making the
request. Using anonymous attr on the img prevents a tainted canvas from
being created. Dont expect to see these cookies when working on
localhost b/c of the way the browser interprets the domain. Still seeing
FlashPepper error when this code runs on localhost after all cookies
have first been deleted.
